### PR TITLE
Fix INJECT_FACTS_AS_VARS deprecation warning

### DIFF
--- a/roles/onepassword/tasks/apt.yml
+++ b/roles/onepassword/tasks/apt.yml
@@ -43,7 +43,7 @@
   become: true
   ansible.builtin.apt_repository:
     repo: >
-      deb [arch={{ [ansible_architecture] | map('extract', onepassword_deb_architecture) | first }} signed-by=/usr/share/keyrings/1password-archive-keyring.gpg]
-      https://downloads.1password.com/linux/debian/{{ [ansible_architecture] | map('extract', onepassword_deb_architecture) | first }} stable main
+      deb [arch={{ [ansible_facts["architecture"]] | map('extract', onepassword_deb_architecture) | first }} signed-by=/usr/share/keyrings/1password-archive-keyring.gpg]
+      https://downloads.1password.com/linux/debian/{{ [ansible_facts["architecture"]] | map('extract', onepassword_deb_architecture) | first }} stable main
     state: present
     filename: 1password

--- a/roles/onepassword/tasks/main.yml
+++ b/roles/onepassword/tasks/main.yml
@@ -3,7 +3,7 @@
   tags: 1password
   ansible.builtin.include_tasks:
     file: apt.yml
-  when: ansible_os_family == "Debian"
+  when: ansible_facts["os_family"] == "Debian"
 
 - name: Install 1password on Debian/Ubuntu
   tags: 1password
@@ -12,10 +12,10 @@
     update_cache: true
     name: 1password
     state: present
-  when: ansible_os_family == "Debian"
+  when: ansible_facts["os_family"] == "Debian"
 
 - name: Install 1password on macOS
   tags: 1password
   ansible.builtin.include_tasks:
     file: homebrew.yml
-  when: ansible_os_family == "Darwin"
+  when: ansible_facts["os_family"] == "Darwin"

--- a/roles/onepassword_chrome/tasks/main.yml
+++ b/roles/onepassword_chrome/tasks/main.yml
@@ -4,7 +4,7 @@
   ansible.builtin.stat:
     path: /opt/1Password/1Password-BrowserSupport
   register: onepassword_chrome_browser_support_debian
-  when: ansible_os_family == "Debian"
+  when: ansible_facts["os_family"] == "Debian"
 
 - name: Create Chrome managed policies directory on Debian/Ubuntu
   tags: 1password_chrome
@@ -13,7 +13,7 @@
     path: /etc/opt/chrome/policies/managed
     state: directory
     mode: '0755'
-  when: ansible_os_family == "Debian"
+  when: ansible_facts["os_family"] == "Debian"
 
 - name: Install 1Password Chrome extension via policy on Debian/Ubuntu
   tags: 1password_chrome
@@ -30,7 +30,7 @@
       }
     dest: /etc/opt/chrome/policies/managed/1password.json
     mode: '0644'
-  when: ansible_os_family == "Debian"
+  when: ansible_facts["os_family"] == "Debian"
 
 - name: Ensure /Library/Managed Preferences exists for Chrome policies on macOS
   tags: 1password_chrome
@@ -39,7 +39,7 @@
     path: /Library/Managed Preferences
     state: directory
     mode: '0755'
-  when: ansible_os_family == "Darwin"
+  when: ansible_facts["os_family"] == "Darwin"
 
 - name: Install 1Password Chrome extension via policy on macOS
   tags: 1password_chrome
@@ -64,4 +64,4 @@
       </plist>
     dest: /Library/Managed Preferences/com.google.Chrome.plist
     mode: '0644'
-  when: ansible_os_family == "Darwin"
+  when: ansible_facts["os_family"] == "Darwin"

--- a/roles/onepassword_cli/tasks/main.yml
+++ b/roles/onepassword_cli/tasks/main.yml
@@ -1,13 +1,13 @@
 ---
 - name: Include vars
   ansible.builtin.include_vars: ../../onepassword/vars/main.yml
-  when: ansible_os_family == "Debian"
+  when: ansible_facts["os_family"] == "Debian"
 
 - name: Install apt repo
   tags: 1password
   ansible.builtin.include_tasks:
     file: ../../onepassword/tasks/apt.yml
-  when: ansible_os_family == "Debian"
+  when: ansible_facts["os_family"] == "Debian"
 
 - name: Install 1password cli on Debian/Ubuntu
   tags: 1password
@@ -16,10 +16,10 @@
     update_cache: true
     pkg:
       - 1password-cli
-  when: ansible_os_family == "Debian"
+  when: ansible_facts["os_family"] == "Debian"
 
 - name: Install 1password cli on macOS
   tags: 1password
   ansible.builtin.include_tasks:
     file: homebrew.yml
-  when: ansible_os_family == "Darwin"
+  when: ansible_facts["os_family"] == "Darwin"

--- a/roles/onepassword_firefox/tasks/main.yml
+++ b/roles/onepassword_firefox/tasks/main.yml
@@ -4,7 +4,7 @@
   ansible.builtin.stat:
     path: /opt/1Password/1Password-BrowserSupport
   register: onepassword_firefox_browser_support_debian
-  when: ansible_os_family == "Debian"
+  when: ansible_facts["os_family"] == "Debian"
 
 - name: Create Firefox policies directory on Debian/Ubuntu
   tags: 1password_firefox
@@ -13,7 +13,7 @@
     path: /etc/firefox/policies
     state: directory
     mode: '0755'
-  when: ansible_os_family == "Debian"
+  when: ansible_facts["os_family"] == "Debian"
 
 - name: Install 1Password Firefox extension via policy on Debian/Ubuntu
   tags: 1password_firefox
@@ -32,7 +32,7 @@
       }
     dest: /etc/firefox/policies/policies.json
     mode: '0644'
-  when: ansible_os_family == "Debian"
+  when: ansible_facts["os_family"] == "Debian"
 
 - name: Create Firefox distribution directory on macOS
   tags: 1password_firefox
@@ -41,7 +41,7 @@
     path: /Applications/Firefox.app/Contents/Resources/distribution
     state: directory
     mode: '0755'
-  when: ansible_os_family == "Darwin"
+  when: ansible_facts["os_family"] == "Darwin"
 
 - name: Install 1Password Firefox extension via policy on macOS
   tags: 1password_firefox
@@ -60,4 +60,4 @@
       }
     dest: /Applications/Firefox.app/Contents/Resources/distribution/policies.json
     mode: '0644'
-  when: ansible_os_family == "Darwin"
+  when: ansible_facts["os_family"] == "Darwin"

--- a/roles/onepassword_safari/tasks/main.yml
+++ b/roles/onepassword_safari/tasks/main.yml
@@ -3,10 +3,10 @@
   tags: 1password_safari
   ansible.builtin.debug:
     msg: "Safari browser is only available on macOS. This role has no effect on Debian/Ubuntu systems."
-  when: ansible_os_family == "Debian"
+  when: ansible_facts["os_family"] == "Debian"
 
 - name: Verify 1Password Safari support on macOS
   tags: 1password_safari
   ansible.builtin.debug:
     msg: "1Password is installed with Safari extension support. To enable the Safari extension: 1) Open Safari, 2) Go to Safari > Settings > Extensions, 3) Enable the 1Password extension"
-  when: ansible_os_family == "Darwin"
+  when: ansible_facts["os_family"] == "Darwin"


### PR DESCRIPTION
## Summary
- Replace `ansible_os_family` with `ansible_facts["os_family"]` across all 5 roles
- Replace `ansible_architecture` with `ansible_facts["architecture"]` in apt.yml
- Resolves the `INJECT_FACTS_AS_VARS` deprecation warning that will become an error in ansible-core 2.24

Fixes #20

## Test plan
- [ ] Run the collection against a Debian/Ubuntu target and verify no deprecation warnings
- [ ] Run the collection against a macOS target and verify no deprecation warnings
- [ ] Verify existing molecule tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)