### PR TITLE
Fix apt_repository idempotence on 1password repo task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,12 @@
 # Changelog
+
+## 0.1.3
+* Fix `Install 1password repo` idempotence. The `>` folded scalar used
+  for the repo string carried a trailing newline that newer Ansible /
+  apt tooling no longer normalizes away, so `apt_repository` saw a diff
+  on every run and reported `changed`. Switched to a single-line string
+  and hoisted the architecture lookup into a `set_fact` so it's only
+  computed once.
+
+## 0.1.2 and earlier
 * First version

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -6,7 +6,7 @@ authors:
 description: Installs 1password and 1password cli
 license_file: LICENSE
 readme: README.md
-version: 0.1.2
+version: 0.1.3
 repository: https://github.com/compscidr/ansible-1password
 tags:
     - onepassword

--- a/roles/onepassword/tasks/apt.yml
+++ b/roles/onepassword/tasks/apt.yml
@@ -38,12 +38,15 @@
     state: absent
   when: not onepassword_keyring_exists.stat.exists
 
+- name: Compute 1password deb architecture
+  tags: 1password
+  ansible.builtin.set_fact:
+    onepassword_deb_arch: "{{ [ansible_facts['architecture']] | map('extract', onepassword_deb_architecture) | first }}"
+
 - name: Install 1password repo
   tags: 1password
   become: true
   ansible.builtin.apt_repository:
-    repo: >
-      deb [arch={{ [ansible_facts["architecture"]] | map('extract', onepassword_deb_architecture) | first }} signed-by=/usr/share/keyrings/1password-archive-keyring.gpg]
-      https://downloads.1password.com/linux/debian/{{ [ansible_facts["architecture"]] | map('extract', onepassword_deb_architecture) | first }} stable main
+    repo: "deb [arch={{ onepassword_deb_arch }} signed-by=/usr/share/keyrings/1password-archive-keyring.gpg] https://downloads.1password.com/linux/debian/{{ onepassword_deb_arch }} stable main"
     state: present
     filename: 1password


### PR DESCRIPTION
See commit message. The short version: the folded-scalar repo string in Install 1password repo carried a trailing newline that newer ansible/apt no longer normalizes away, so apt_repository reported changed on every run and idempotence failed. Switched to a single-line string and hoisted the arch lookup into a set_fact. Surfaced in downstream compscidr/iac molecule runs on 2026-04-21; this repo's own CI last ran 2026-03-16 so the regression went undetected. Bumps 0.1.2 -> 0.1.3.