### PR TITLE
Fix apt repo idempotence by writing deb822 file directly (0.1.4 wasn't enough)

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -6,7 +6,7 @@ authors:
 description: Installs 1password and 1password cli
 license_file: LICENSE
 readme: README.md
-version: 0.1.4
+version: 0.1.5
 repository: https://github.com/compscidr/ansible-1password
 tags:
     - onepassword

--- a/roles/onepassword/tasks/apt.yml
+++ b/roles/onepassword/tasks/apt.yml
@@ -43,10 +43,39 @@
   ansible.builtin.set_fact:
     onepassword_deb_arch: "{{ [ansible_facts['architecture']] | map('extract', onepassword_deb_architecture) | first }}"
 
-- name: Install 1password repo
+# Write the repo file directly in deb822 format. `apt_repository` has
+# a roundtrip comparison that newer ansible-core / apt tooling flags as
+# `changed` on every run even when the contents are equivalent, which
+# breaks idempotence. `copy` writes exact bytes and compares by hash,
+# so it's reliably idempotent.
+- name: Install 1password repo (deb822)
   tags: 1password
   become: true
-  ansible.builtin.apt_repository:
-    repo: "deb [arch={{ onepassword_deb_arch }} signed-by=/usr/share/keyrings/1password-archive-keyring.gpg] https://downloads.1password.com/linux/debian/{{ onepassword_deb_arch }} stable main"
-    state: present
-    filename: 1password
+  ansible.builtin.copy:
+    dest: /etc/apt/sources.list.d/1password.sources
+    content: |
+      Types: deb
+      URIs: https://downloads.1password.com/linux/debian/{{ onepassword_deb_arch }}
+      Suites: stable
+      Components: main
+      Architectures: {{ onepassword_deb_arch }}
+      Signed-By: /usr/share/keyrings/1password-archive-keyring.gpg
+    mode: '0644'
+    owner: root
+    group: root
+  register: onepassword_repo_result
+
+- name: Remove legacy 1password.list if present
+  tags: 1password
+  become: true
+  ansible.builtin.file:
+    path: /etc/apt/sources.list.d/1password.list
+    state: absent
+  register: onepassword_legacy_repo_removed
+
+- name: Update apt cache after 1password repo changes
+  tags: 1password
+  become: true
+  ansible.builtin.apt:
+    update_cache: true
+  when: onepassword_repo_result is changed or onepassword_legacy_repo_removed is changed


### PR DESCRIPTION
0.1.4's folded-scalar fix didn't resolve the idempotence issue — downstream molecule runs still flag `compscidr.onepassword.onepassword_cli : Install 1password repo` as `changed` on the idempotence pass.

Observed pattern in the downstream run: when BOTH the `onepassword` role and the `onepassword_cli` role include the same `apt.yml`, the task reports `ok` for the `onepassword` role but `changed` for `onepassword_cli` on the second pass. Something between the two role invocations mutates the repo file such that `apt_repository`'s read-back-and-compare logic in ansible-core 2.18+ flags a difference every time (apt or the module reformats `1password.list` between runs).

Fix: bypass `apt_repository` entirely. Write `/etc/apt/sources.list.d/1password.sources` in deb822 format using `ansible.builtin.copy` — deterministic bytes, hash-compared idempotence. Clean up any legacy `.list` file from prior role versions. Explicitly run `apt update` when either changes (since `copy`/`file` don't auto-trigger the refresh `apt_repository` does).

Bumps 0.1.4 → 0.1.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)